### PR TITLE
Adding "report" directory creation to tandemmapper.py

### DIFF
--- a/tandemmapper.py
+++ b/tandemmapper.py
@@ -47,6 +47,9 @@ def main(assembly_fnames, nano_reads_fname, pacbio_reads_fname, hifi_reads_fname
     out_dir = abspath(out_dir)
     if not isdir(out_dir):
         os.makedirs(out_dir)
+    report_dir = join(out_dir, "report")
+    if not isdir(report_dir):
+        os.makedirs(report_dir)
     tmp_dir = join(out_dir, "tmp")
     if not isdir(tmp_dir):
         os.makedirs(tmp_dir)


### PR DESCRIPTION
When running `tandemmapper.py` on its own without running `tandemquast.py` the execution will crash with the following error:

```
Traceback (most recent call last):
  File "./tandemmapper.py", line 80, in <module>
    main()
  File "/usr/local/Caskroom/miniconda/base/envs/tandemNew/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/Caskroom/miniconda/base/envs/tandemNew/lib/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/Caskroom/miniconda/base/envs/tandemNew/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/Caskroom/miniconda/base/envs/tandemNew/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "./tandemmapper.py", line 72, in main
    make_alignments.do(assemblies, reads_fname, reads_real_coords, out_dir, threads, no_reuse, no_nucl_alignment)
  File "/Users/lucblassel/gitPulls/TandemTools/scripts/make_alignments.py", line 208, in do
    make_plotly_noise(assemblies, all_data, out_dir)
  File "/Users/lucblassel/gitPulls/TandemTools/scripts/reporting.py", line 130, in make_plotly_noise
    with open(bed_fname, "w") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/Users/lucblassel/gitPulls/TandemTools/tandemRes/report/kmers_dist_diff.bed'
```

This is because `bed_fname` is `<out_dir>/report/kmers_dist_diff.bed`  in `scripts/reporting.py`

However, the `<out_dir>/report` subdirectory is never created in `tandemmapper.py` but it is created in `tandemquast.py`

This PR aims to fix this problem by adding the creation of the `<out_dir>/report` subdirectory if it does not already exist. 